### PR TITLE
Add option to prefer-const rule, ignoreReadBeforeAssign.

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ module.exports = {
     'no-var': 2,
     'object-shorthand': [ 2, 'methods' ],
     'prefer-arrow-callback': 2,
-    'prefer-const': 2,
+    'prefer-const': [ 2, { ignoreReadBeforeAssign: true } ],
     'prefer-reflect': 0,
     'prefer-spread': 0,
     'prefer-template': 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vinli",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Vinli ESLint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This allows us to use let to declare a variable whose definition is the return of a function that needs the variable previously declared. See http://eslint.org/docs/rules/prefer-const\#ignorereadbeforeassign for more.
