### PR TITLE
console.log is error, tighten up mocha tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     // possible errors
     'comma-dangle': [ 2, 'never' ],
     'no-cond-assign': [ 2, 'always' ],
-    'no-console': 1,
+    'no-console': [ 2, { allow: [ "info", "warn", "error" ] } ],
     'no-constant-condition': 2, // Edge case -> put comment,
     'no-control-regex': 1,
     'no-debugger': 1,

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ module.exports = merge({}, require('./index'), {
 
   rules: {
     // possible errors
-    'no-console': 0,
+    'no-console': [ 2, { allow: [ "info", "warn", "error"] } ],
 
     // Node.js and CommonJS
     'object-shorthand': 0,

--- a/server/tests.js
+++ b/server/tests.js
@@ -8,6 +8,8 @@ module.exports = {
     'max-depth': 0,
     'max-len': 0,
     'mocha/no-exclusive-tests': 2,
+    'mocha/no-global-tests': 2,
+    'mocha/no-identical-title': 2,
     'no-unused-expressions': 0 // fix chai property assertions at the end of the chain
   }
 }


### PR DESCRIPTION
This will affect most services, but be fixed easily: On most services there are a couple `console.log` around server setup, those can be changed to `console.info`.

There shouldn't be any global tests anyways and few to no identical title tests.

Plan is to do a minor release.